### PR TITLE
Embed manifest resource using MSVC toolchain, to avoid installer heuristics.

### DIFF
--- a/cargo-install-update-manifest.rc
+++ b/cargo-install-update-manifest.rc
@@ -1,2 +1,2 @@
-#include "winuser.h"
-1 RT_MANIFEST cargo-install-update.exe.manifest
+#define RT_MANIFEST 24
+1 RT_MANIFEST "cargo-install-update.exe.manifest"


### PR DESCRIPTION
I tested it on Windows 10 + MSVC 2015. The manifest resource was linked into .exe, which don't requires administrator privilege to be run anymore. (I didn't touch existing code for gnu toolchain, it will continue works, if it did works.)

See comments on #11 for more information.
Fixes #11
Fixes #14

@nabijaczleweli r?