### PR TITLE
Sort list of packages by update status

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["cargo", "update", "plugin", "subcommand"]
 license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
-version = "0.6.2"
+version = "0.6.3"
 # Remember to also update in cargo-install-update.md
 authors = ["nabijaczleweli <nabijaczleweli@gmail.com>",
            "Yann Simon <yann.simon.fr@gmail.com>",

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.6.2-{build}
+version: 0.6.3-{build}
 
 skip_tags: false
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,19 +59,31 @@ fn actual_main() -> Result<(), i32> {
     {
         let mut out = TabWriter::new(stdout());
         writeln!(out, "Package\tInstalled\tLatest\tNeeds update").unwrap();
+        let mut todo = Vec::new();
+        let mut to_ignore = Vec::new();
+
+        // sort the packages into two vecs by update status
         for package in &packages {
+            if package.version < *package.newest_version.as_ref().unwrap() {
+                todo.push((package, "Yes"));
+            } else {
+                to_ignore.push((package, "No"));
+            };
+        }
+
+        // combine the two vecs back together
+        todo.append(&mut to_ignore);
+
+        for &(package, needs_update) in &todo {
             writeln!(out,
                      "{}\tv{}\tv{}\t{}",
                      package.name,
                      package.version,
                      package.newest_version.as_ref().unwrap(),
-                     if package.version < *package.newest_version.as_ref().unwrap() {
-                         "Yes"
-                     } else {
-                         "No"
-                     })
+                     needs_update)
                 .unwrap();
         }
+
         writeln!(out, "").unwrap();
         out.flush().unwrap();
     }


### PR DESCRIPTION
This should improve the readability of `cargo-update` by displaying the most interesting information first. I use this tool at least once a week, and I always have to scan the `Needs update` column and then try to match the ones that say `yes` to the crate names very quickly before they scroll off the screen.

On another note, while this crate is very useful, it is _extremely_ hard to find by googling.