### PR TITLE
Find rc.exe in build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ json = "0.11"
 toml = "0.2"
 
 
+[target.'cfg(all(windows, target_env = "msvc"))'.build-dependencies]
+winreg = { version = "0.4", default-features = false }
+
+
 [[bin]]
 name = "cargo-install-update"
 test = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ clap = "2.18"
 json = "0.11"
 toml = "0.2"
 
-
 [target.'cfg(all(windows, target_env = "msvc"))'.build-dependencies]
 winreg = { version = "0.4", default-features = false }
 

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,11 @@ extern crate winreg;
 use std::process::Command;
 use std::path::{Path, PathBuf};
 use std::env;
+#[cfg(all(windows, target_env = "msvc"))]
+use winreg::enums::*;
 
 #[cfg(not(windows))]
-fn main() { }
+fn main() {}
 
 #[cfg(windows)]
 fn main() {
@@ -18,73 +20,67 @@ fn main() {
 #[cfg(all(windows, target_env = "msvc"))]
 fn compile_resource(out_dir: &str) {
     // `.res`es are linkable under MSVC as well as normal libraries.
+    let rc_path = find_windows_sdk_bin_dir().and_then(|mut x| {
+        x.push("rc.exe");
+        if x.exists() { Some(x) } else { None }
+    });
 
-    fn find_windows_sdk_bin_dir() -> Option<PathBuf> {
-        use winreg::enums::*;
-
-        #[derive(Clone, Copy)]
-        enum Arch {
-            X86,
-            X64,
-        }
-
-        // Windows 8 - 10
-        fn find_windows_kits_bin_dir(key: &str, arch: Arch) -> Option<PathBuf> {
-            let res = winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
-                .open_subkey_with_flags("SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", KEY_QUERY_VALUE)
-                .and_then(|reg_key| reg_key.get_value::<String, _>(key));
-
-            match res {
-                Ok(root_dir) => {
-                    let mut p = PathBuf::from(root_dir);
-                    match arch {
-                        Arch::X86 => p.push("bin\\x86"),
-                        Arch::X64 => p.push("bin\\x64"),
-                    }
-                    if p.is_dir() { Some(p) } else { None }
-                }
-                Err(_) => None
-            }
-        }
-
-        // Windows Vista - 7
-        fn find_latest_windows_sdk_bin_dir(arch: Arch) -> Option<PathBuf> {
-            let res = winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
-                .open_subkey_with_flags("SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows", KEY_QUERY_VALUE)
-                .and_then(|reg_key| reg_key.get_value::<String, _>("CurrentInstallFolder"));
-
-            match res {
-                Ok(root_dir) => {
-                    let mut p = PathBuf::from(root_dir);
-                    match arch {
-                        Arch::X86 => p.push("Bin"),
-                        Arch::X64 => p.push("Bin\\x64"),
-                    }
-                    if p.is_dir() { Some(p) } else { None }
-                }
-                Err(_) => None
-            }
-        }
-
-        let arch = if env::var("TARGET").unwrap().starts_with("x86_64") { Arch::X64 } else { Arch::X86 };
-
-        find_windows_kits_bin_dir("KitsRoot10", arch)
-            .or_else(|| find_windows_kits_bin_dir("KitsRoot81", arch))
-            .or_else(|| find_windows_kits_bin_dir("KitsRoot", arch))
-            .or_else(|| find_latest_windows_sdk_bin_dir(arch))
-    }
-
-    let rc_exe = Path::new("rc.exe");
-    let rc_path = find_windows_sdk_bin_dir()
-        .and_then(|mut x| {
-            x.push(rc_exe);
-            if x.exists() { Some(x) } else { None }
-        });
-
-    Command::new(if let Some(ref x) = rc_path { x } else { rc_exe })
+    Command::new(rc_path.as_ref().map_or(Path::new("rc.exe"), Path::new))
         .args(&["/fo", &format!("{}/cargo-install-update-manifest.lib", out_dir), "cargo-install-update-manifest.rc"])
         .status()
         .expect("Are you sure you have RC.EXE in your $PATH?");
+}
+
+#[cfg(all(windows, target_env = "msvc"))]
+fn find_windows_sdk_bin_dir() -> Option<PathBuf> {
+    #[derive(Clone, Copy)]
+    enum Arch {
+        X86,
+        X64,
+    }
+
+    // Windows 8 - 10
+    fn find_windows_kits_bin_dir(key: &str, arch: Arch) -> Option<PathBuf> {
+        winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey_with_flags(r"SOFTWARE\Microsoft\Windows Kits\Installed Roots", KEY_QUERY_VALUE)
+            .and_then(|reg_key| reg_key.get_value::<String, _>(key))
+            .ok()
+            .and_then(|root_dir| {
+                let mut p = PathBuf::from(root_dir);
+                match arch {
+                    Arch::X86 => p.push(r"bin\x86"),
+                    Arch::X64 => p.push(r"bin\x64"),
+                }
+                if p.is_dir() { Some(p) } else { None }
+            })
+    }
+
+    // Windows Vista - 7
+    fn find_latest_windows_sdk_bin_dir(arch: Arch) -> Option<PathBuf> {
+        winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
+            .open_subkey_with_flags(r"SOFTWARE\Microsoft\Microsoft SDKs\Windows", KEY_QUERY_VALUE)
+            .and_then(|reg_key| reg_key.get_value::<String, _>("CurrentInstallFolder"))
+            .ok()
+            .and_then(|root_dir| {
+                let mut p = PathBuf::from(root_dir);
+                match arch {
+                    Arch::X86 => p.push("Bin"),
+                    Arch::X64 => p.push(r"Bin\x64"),
+                }
+                if p.is_dir() { Some(p) } else { None }
+            })
+    }
+
+    let arch = if env::var("TARGET").unwrap().starts_with("x86_64") {
+        Arch::X64
+    } else {
+        Arch::X86
+    };
+
+    find_windows_kits_bin_dir("KitsRoot10", arch)
+        .or_else(|| find_windows_kits_bin_dir("KitsRoot81", arch))
+        .or_else(|| find_windows_kits_bin_dir("KitsRoot", arch))
+        .or_else(|| find_latest_windows_sdk_bin_dir(arch))
 }
 
 #[cfg(all(windows, not(target_env = "msvc")))]

--- a/build.rs
+++ b/build.rs
@@ -1,33 +1,103 @@
+#[cfg(all(windows, target_env = "msvc"))]
+extern crate winreg;
+
 use std::process::Command;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::env;
 
+#[cfg(not(windows))]
+fn main() { }
+
+#[cfg(windows)]
 fn main() {
-    if cfg!(not(target_os = "windows")) {
-        return;
-    }
-
     let out_dir = env::var("OUT_DIR").unwrap();
+    compile_resource(&out_dir);
+    println!("cargo:rustc-link-search=native={}", out_dir);
+}
 
-    if cfg!(target_env = "msvc") {
-        // `.res`es are linkable under MSVC as well as normal libraries.
-        Command::new("rc")
-            .args(&["/fo", &format!("{}/cargo-install-update-manifest.lib", out_dir), "cargo-install-update-manifest.rc"])
-            .status()
-            .expect("Are you sure you have RC.EXE in your $PATH?");
-    } else {
-        Command::new("windres")
-            .args(&["--input", "cargo-install-update-manifest.rc", "--output-format=coff", "--output"])
-            .arg(&format!("{}/cargo-install-update-manifest.res", out_dir))
-            .status()
-            .unwrap();
+#[cfg(all(windows, target_env = "msvc"))]
+fn compile_resource(out_dir: &str) {
+    // `.res`es are linkable under MSVC as well as normal libraries.
 
-        Command::new("ar")
-            .args(&["crs", "libcargo-install-update-manifest.a", "cargo-install-update-manifest.res"])
-            .current_dir(&Path::new(&out_dir))
-            .status()
-            .unwrap();
+    fn find_windows_sdk_bin_dir() -> Option<PathBuf> {
+        use winreg::enums::*;
+
+        #[derive(Clone, Copy)]
+        enum Arch {
+            X86,
+            X64,
+        }
+
+        // Windows 8 - 10
+        fn find_windows_kits_bin_dir(key: &str, arch: Arch) -> Option<PathBuf> {
+            let res = winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
+                .open_subkey_with_flags("SOFTWARE\\Microsoft\\Windows Kits\\Installed Roots", KEY_QUERY_VALUE)
+                .and_then(|reg_key| reg_key.get_value::<String, _>(key));
+
+            match res {
+                Ok(root_dir) => {
+                    let mut p = PathBuf::from(root_dir);
+                    match arch {
+                        Arch::X86 => p.push("bin\\x86"),
+                        Arch::X64 => p.push("bin\\x64"),
+                    }
+                    if p.is_dir() { Some(p) } else { None }
+                }
+                Err(_) => None
+            }
+        }
+
+        // Windows Vista - 7
+        fn find_latest_windows_sdk_bin_dir(arch: Arch) -> Option<PathBuf> {
+            let res = winreg::RegKey::predef(HKEY_LOCAL_MACHINE)
+                .open_subkey_with_flags("SOFTWARE\\Microsoft\\Microsoft SDKs\\Windows", KEY_QUERY_VALUE)
+                .and_then(|reg_key| reg_key.get_value::<String, _>("CurrentInstallFolder"));
+
+            match res {
+                Ok(root_dir) => {
+                    let mut p = PathBuf::from(root_dir);
+                    match arch {
+                        Arch::X86 => p.push("Bin"),
+                        Arch::X64 => p.push("Bin\\x64"),
+                    }
+                    if p.is_dir() { Some(p) } else { None }
+                }
+                Err(_) => None
+            }
+        }
+
+        let arch = if env::var("TARGET").unwrap().starts_with("x86_64") { Arch::X64 } else { Arch::X86 };
+
+        find_windows_kits_bin_dir("KitsRoot10", arch)
+            .or_else(|| find_windows_kits_bin_dir("KitsRoot81", arch))
+            .or_else(|| find_windows_kits_bin_dir("KitsRoot", arch))
+            .or_else(|| find_latest_windows_sdk_bin_dir(arch))
     }
 
-    println!("cargo:rustc-link-search=native={}", out_dir);
+    let rc_exe = Path::new("rc.exe");
+    let rc_path = find_windows_sdk_bin_dir()
+        .and_then(|mut x| {
+            x.push(rc_exe);
+            if x.exists() { Some(x) } else { None }
+        });
+
+    Command::new(if let Some(ref x) = rc_path { x } else { rc_exe })
+        .args(&["/fo", &format!("{}/cargo-install-update-manifest.lib", out_dir), "cargo-install-update-manifest.rc"])
+        .status()
+        .expect("Are you sure you have RC.EXE in your $PATH?");
+}
+
+#[cfg(all(windows, not(target_env = "msvc")))]
+fn compile_resource(out_dir: &str) {
+    Command::new("windres")
+        .args(&["--input", "cargo-install-update-manifest.rc", "--output-format=coff", "--output"])
+        .arg(&format!("{}/cargo-install-update-manifest.res", out_dir))
+        .status()
+        .unwrap();
+
+    Command::new("ar")
+        .args(&["crs", "libcargo-install-update-manifest.a", "cargo-install-update-manifest.res"])
+        .current_dir(&Path::new(&out_dir))
+        .status()
+        .unwrap();
 }


### PR DESCRIPTION
In MSVC environment, I had to set the path of Windows SDK to the PATH environment variable to build cargo-update. So I suggest that build.rs find the path automatically.