### PR TITLE
Simplify parsing of crate versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,12 +27,12 @@ lazy_static = "0.2"
 array_tool = "0.3"
 tabwriter = "1.0"
 lazysort = "0.1"
-semver = "0.6"
+semver = { version = "0.7", features = ["serde"] }
 regex = "0.2"
 serde = "1.0"
+serde_json = "1.0"
 git2 = "0.6"
 clap = "2.23"
-json = "0.11"
 toml = "0.4"
 
 [build-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ extern crate git2;
 #[macro_use]
 extern crate clap;
 extern crate toml;
-extern crate json;
+extern crate serde_json;
 
 mod options;
 


### PR DESCRIPTION
I get lost when I see things like `Semver::parse(j["vers"].as_str().unwrap()).unwrap()`.