### PR TITLE
Switch package version seperator to `:` to match cargo package-ids.

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -181,7 +181,7 @@ fn cargo_dir_validator(s: String) -> Result<(), String> {
 }
 
 fn package_parse(s: String) -> Result<(String, Option<Semver>), String> {
-    if let Some(idx) = s.find('#') {
+    if let Some(idx) = s.find(':') {
         Ok((s[0..idx].to_string(),
             Some(try!(Semver::parse(&s[idx + 1..]).map_err(|e| format!("Version {} provided for package {} invalid: {}", &s[idx + 1..], &s[0..idx], e))))))
     } else {


### PR DESCRIPTION
See http://doc.crates.io/pkgid-spec.html