### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn actual_main() -> Result<(), i32> {
     let mut packages = cargo_update::ops::installed_main_repo_packages(&crates_file);
 
     if !opts.to_update.is_empty() {
-        packages = cargo_update::ops::intersect_packages(packages, &opts.to_update, opts.install);
+        packages = cargo_update::ops::intersect_packages(&packages, &opts.to_update, opts.install);
     }
 
     {
@@ -135,7 +135,7 @@ fn actual_main() -> Result<(), i32> {
                     Ok(()) => (s + 1, e, r),
                     Err((pr, pn)) => {
                         e.push(pn);
-                        (s, e, r.or(Some(pr)))
+                        (s, e, r.or_else(|| Some(pr)))
                     }
                 });
 

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -272,14 +272,14 @@ pub fn installed_main_repo_packages(crates_file: &Path) -> Vec<MainRepoPackage> 
 /// #     vec![MainRepoPackage::parse("cargo-outdated 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
 /// #          MainRepoPackage::parse("racer 1.2.10 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
 /// #          MainRepoPackage::parse("rustfmt 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)").unwrap()];
-/// installed_packages = intersect_packages(installed_packages, &packages_to_update, false);
+/// installed_packages = intersect_packages(&installed_packages, &packages_to_update, false);
 /// # assert_eq!(&installed_packages,
 /// #   &[MainRepoPackage::parse("cargo-outdated 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
 /// #     MainRepoPackage::parse("racer 1.2.10 (registry+https://github.com/rust-lang/crates.io-index)").unwrap()]);
 /// ```
-pub fn intersect_packages(installed: Vec<MainRepoPackage>, to_update: &[(String, Option<Semver>)], allow_installs: bool) -> Vec<MainRepoPackage> {
+pub fn intersect_packages(installed: &[MainRepoPackage], to_update: &[(String, Option<Semver>)], allow_installs: bool) -> Vec<MainRepoPackage> {
     installed.iter()
-        .filter(|p| to_update.iter().find(|u| p.name == u.0).is_some())
+        .filter(|p| to_update.iter().any(|u| p.name == u.0))
         .cloned()
         .map(|p| {
             MainRepoPackage {

--- a/tests/ops/mod.rs
+++ b/tests/ops/mod.rs
@@ -9,7 +9,7 @@ mod get_index_path;
 
 #[test]
 fn intersect_packages() {
-    assert_eq!(ops::intersect_packages(vec![MainRepoPackage::parse("cargo-outdated 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
+    assert_eq!(ops::intersect_packages(&[MainRepoPackage::parse("cargo-outdated 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
                                             MainRepoPackage::parse("cargo-count 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)").unwrap(),
                                             MainRepoPackage::parse("racer 1.2.10 (registry+https://github.com/rust-lang/crates.io-index)").unwrap()],
                                        &[("cargo-count".to_string(), None), ("racer".to_string(), None), ("checksums".to_string(), None)],


### PR DESCRIPTION
Fixed:
```
warning: this argument is passed by value, but not consumed in the function body
   --> src/ops/mod.rs:280:38
    |
280 | pub fn intersect_packages(installed: Vec<MainRepoPackage>, to_update: &[(String, Option<Semver>)], allow_installs: bool) -> Vec<MainRepoPackage> {
    |                                      ^^^^^^^^^^^^^^^^^^^^ help: consider changing the type to `&[MainRepoPackage]`
    |
    = note: #[warn(needless_pass_by_value)] on by default
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_pass_by_value

warning: called `is_some()` after searching an `Iterator` with find. This is more succinctly expressed by calling `any()`.
   --> src/ops/mod.rs:282:21
    |
282 |         .filter(|p| to_update.iter().find(|u| p.name == u.0).is_some())
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: #[warn(search_is_some)] on by default
    = note: replace `find(|u| p.name == u.0).is_some()` with `any(|u| p.name == u.0)`
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#search_is_some

warning: use of `or` followed by a function call
   --> src/main.rs:138:32
    |
138 |                         (s, e, r.or(Some(pr)))
    |                                ^^^^^^^^^^^^^^ help: try this `r.or_else(|| Some(pr))`
    |
    = note: #[warn(or_fun_call)] on by default
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#or_fun_call
```

Not fixed, I'm not sure about it ("trait `std::ops::Fn<(std::string::String,)>` is required"):
```
warning: this argument is passed by value, but not consumed in the function body
   --> src/options.rs:179:27
    |
179 | fn cargo_dir_validator(s: String) -> Result<(), String> {
    |                           ^^^^^^ help: consider changing the type to `&str`
    |
    = note: #[warn(needless_pass_by_value)] on by default
    = help: for further information visit https://github.com/Manishearth/rust-clippy/wiki#needless_pass_by_value
```

Tests are passed:
```
   Running target/debug/deps/lib-7f01fd7d82c1259e
...
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

   Doc-tests cargo-update
...
test result: ok. 17 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```