### PR TITLE
docs(README): Add installation instructions for cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ A [`cargo` subcommand](https://github.com/rust-lang/cargo/wiki/Third-party-cargo
 
 ### Installation
 
+Make sure that `cmake` is installed on your system. Example for installing it on Ubuntu:
+
+```shell
+sudo apt install cmake
+```
+
+Then install cargo-update with cargo:
+
 ```shell
 cargo install cargo-update
 ```


### PR DESCRIPTION
In order to compile a dependency of cargo-update we need cmake:

```
error: failed to run custom build command for `libssh2-sys v0.2.6`
process didn't exit successfully: `/tmp/cargo-install.QZUj9lXILmye/release/build/libssh2-sys-bcb99ce633d30985/build-script-build` (exit code: 101)
--- stdout
running: "cmake" "/home/klausi/.cargo/registry/src/github.com-1ecc6299db9ec823/libssh2-sys-0.2.6/libssh2" "-DCRYPTO_BACKEND=OpenSSL" "-DBUILD_SHARED_LIBS=OFF" "-DENABLE_ZLIB_COMPRESSION=ON" "-DCMAKE_INSTALL_LIBDIR=lib" "-DBUILD_EXAMPLES=OFF" "-DBUILD_TESTING=OFF" "-DCMAKE_INSTALL_PREFIX=/tmp/cargo-install.QZUj9lXILmye/release/build/libssh2-sys-033b626b5406e513/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++" "-DCMAKE_BUILD_TYPE=Release"

--- stderr
fatal: Not a git repository (or any parent up to mount point /home)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
thread 'main' panicked at '
failed to execute command: No such file or directory (os error 2)
is `cmake` not installed?
```

Add that to the installation instructions.