### PR TITLE
Really read the latest modified index dir

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ fn actual_main() -> Result<(), i32> {
         2
     }));
     let latest_registry = try!(registry_repo.revparse_single("origin/master").map_err(|_| {
-        println!("Failed read master branch of registry repositry at {}.", registry.display());
+        println!("Failed to read master branch of registry repository at {}.", registry.display());
         2
     }));
 


### PR DESCRIPTION
The previous code used the directory last-modified date to decide
which is the newest index checkout. However, this doesn't account
for the possibility of files within the directory that have been
touched more recently than the directory itself. I don't know how
this situation arises but my guess is it has to do with switching
cargo versions back and forth using rustup.

I also included some minor typo fixes.

Ref: #32 