### PR TITLE
instead of searching for unlikely results on crates.io, do a normal

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn actual_main() -> Result<(), i32> {
 
     {
         // Searching for "" will just update the registry
-        let search_res = Command::new("cargo").arg("search").arg("\u{200C}").status().unwrap();
+        let search_res = Command::new("cargo").arg("search").arg("").output().unwrap().status;
         if !search_res.success() {
             return Err(search_res.code().unwrap_or(-1));
         }


### PR DESCRIPTION
search but discard output in order to update the database.