### PR TITLE
Specifying features with install-update-config is broken on nightly

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -156,13 +156,13 @@ fn actual_main() -> Result<(), i32> {
                     let install_res = if let Some(cfg) = configuration.get(&package.name) {
                             Command::new("cargo")
                                 .args(&cfg.cargo_args()[..])
-                                .arg(&package.name)
                                 .arg("--vers")
                                 .arg(if let Some(tv) = cfg.target_version.as_ref() {
                                     tv.to_string()
                                 } else {
                                     package.update_to_version().unwrap().to_string()
                                 })
+                                .arg(&package.name)
                                 .status()
                         } else {
                             Command::new("cargo")


### PR DESCRIPTION
On nightly cargo changed how it processes the `--features` flag. Instead of a single argument it now takes a list of arguments.
```
        --features <FEATURES>...    Space-separated list of features to activate
```

This is a problem, since now if now other argument follows, then the `package_name` will be treated as another feature, which then leads to an error message.
This change fixes the problem by emitting the `--vers` flag before the `package_name`