### PR TITLE
Fix compiler error: cannot borrow `package.name` as immutable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -93,9 +93,10 @@ fn actual_main() -> Result<(), i32> {
         })?;
 
     for package in &mut packages {
+        let package_name = &package.name.clone();
         package.pull_version(&latest_registry.as_commit().unwrap().tree().unwrap(),
                              &registry_repo,
-                             configuration.get(&package.name).and_then(|c| c.install_prereleases));
+                             configuration.get(package_name).and_then(|c| c.install_prereleases));
     }
 
     if !opts.quiet {


### PR DESCRIPTION
This PR fixes the following compiler error (same as issue #116):

```
error[E0502]: cannot borrow `package.name` as immutable because `*package` is also borrowed as mutable
  --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/cargo-update-2.3.0/src/main.rs:98:49
   |
96 |         package.pull_version(&latest_registry.as_commit().unwrap().tree().unwrap(),
   |         ------- mutable borrow occurs here
97 |                              &registry_repo,
98 |                              configuration.get(&package.name).and_then(|c| c.install_prereleases));
   |                                                 ^^^^^^^^^^^^ immutable borrow occurs here        - mutable borrow ends here
```