### PR TITLE
Update crates versions (especially, git2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ exclude = ["*.enc"]
 # https://travis-ci.org/nabijaczleweli/cargo-update/jobs/611381166#L271 with unicode-normalization 0.1.9
 # h/t to @elichai in https://github.com/nabijaczleweli/cargo-update/issues/119#issuecomment-560116619
 # for suggesting using a `=` dep instead of a patch
-unicode-normalization = "=0.1.9"
+unicode-normalization = "0.1"
 serde_derive = "1.0"
 lazy_static = "1.4"
 array_tool = "1.0"
@@ -49,18 +49,18 @@ lazysort = "0.2"
 # indirect via aho-corastick via regex
 # naming constants with `_` is unstable (see issue #54912)
 # non exhaustive is an experimental feature (see issue #44109)
-memchr = "=2.3.4"
+memchr = "2.4.1"
 regex = "1.3"
 serde = "1.0"
 # indirect via url
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/748120410#L254 vs https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/762755678#L262
-idna = "=0.2.0"
-git2 = "0.11"
-dirs = "2.0"
-json = "0.11"
+idna = "0.2.3"
+git2 = "0.13"
+dirs = "3.0"
+json = "0.12"
 toml = "0.5"
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/748120410#L226 vs https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/762754635#L237
-hex = "=0.4.2"
+hex = "0.4"
 url = "2.1"
 
 [dependencies.semver]


### PR DESCRIPTION
I had problem installing cargo-update using "cargo install cargo-update" with aarch64-darwin rust toochain setup.

It seems there has been some issues about finding and including/linking iconv library resources, when there is libiconv installed through macports.

- https://github.com/rust-lang/git2-rs/issues/263
- https://github.com/cargo-generate/cargo-generate/issues/341#issuecomment-838156077

I tried to update git2-rs and some other packages that does not break build and test, and it worked. (Though there was some comment of someone who solved problem by deactivating macports libiconv. I did not deactivate it, and did update `cargo.toml` )