### PR TITLE
Fix usage string in help prompt

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -74,6 +74,7 @@ impl Options {
     /// Parse `env`-wide command-line arguments into an `Options` instance
     pub fn parse() -> Options {
         let matches = App::new("cargo")
+            .bin_name("cargo")
             .settings(&[AppSettings::ColoredHelp, AppSettings::ArgRequiredElseHelp, AppSettings::GlobalVersion, AppSettings::SubcommandRequired])
             .subcommand(SubCommand::with_name("install-update")
                 .version(crate_version!())
@@ -171,6 +172,7 @@ impl ConfigOptions {
     /// Parse `env`-wide command-line arguments into a `ConfigOptions` instance
     pub fn parse() -> ConfigOptions {
         let matches = App::new("cargo")
+            .bin_name("cargo")
             .settings(&[AppSettings::ColoredHelp, AppSettings::ArgRequiredElseHelp, AppSettings::GlobalVersion, AppSettings::SubcommandRequired])
             .subcommand(SubCommand::with_name("install-update-config")
                 .version(crate_version!())


### PR DESCRIPTION
Adjusts the clap-perceived binary name so that the usage string in help becomes:

```console
USAGE:
    cargo install-update [FLAGS] [OPTIONS] [--] [PACKAGE]...
```