### PR TITLE
Fix handling of --cargo-dir argument

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -231,6 +231,7 @@ fn actual_main() -> Result<(), i32> {
                             if opts.install_cargo == "cargo" && registry_name == "crates-io" && opts.cargo_install_args.is_empty() &&
                                (cfg == None || cfg == Some(&Default::default())) {
                                     Command::new("cargo-binstall")
+                                        .args(["--root", opts.cargo_dir.1.to_str().unwrap()])
                                         .arg("--no-confirm")
                                         .arg("--version")
                                         .arg(&format!("={}", package.update_to_version().unwrap()))
@@ -244,6 +245,7 @@ fn actual_main() -> Result<(), i32> {
                                 .or_else(|_| if let Some(cfg) = cfg {
                                     Command::new(&opts.install_cargo)
                                         .args(cfg.cargo_args(&package.executables).iter().map(AsRef::as_ref))
+                                        .args(["--root", opts.cargo_dir.1.to_str().unwrap()])
                                         .args(if opts.quiet { Some("--quiet") } else { None })
                                         .arg("--version")
                                         .arg(if let Some(tv) = cfg.target_version.as_ref() {
@@ -259,6 +261,7 @@ fn actual_main() -> Result<(), i32> {
                                 } else {
                                     Command::new(&opts.install_cargo)
                                         .arg("install")
+                                        .args(["--root", opts.cargo_dir.1.to_str().unwrap()])
                                         .arg("-f")
                                         .args(if opts.quiet { Some("--quiet") } else { None })
                                         .arg("--version")
@@ -381,6 +384,7 @@ fn actual_main() -> Result<(), i32> {
                         let install_res = if let Some(cfg) = configuration.get(&package.name) {
                                 let mut cmd = Command::new(&opts.install_cargo);
                                 cmd.args(cfg.cargo_args(package.executables).iter().map(AsRef::as_ref))
+                                    .args(["--root", opts.cargo_dir.1.to_str().unwrap()])
                                     .args(if opts.quiet { Some("--quiet") } else { None })
                                     .arg("--git")
                                     .arg(&package.url)
@@ -392,6 +396,7 @@ fn actual_main() -> Result<(), i32> {
                             } else {
                                 let mut cmd = Command::new(&opts.install_cargo);
                                 cmd.arg("install")
+                                    .args(["--root", opts.cargo_dir.1.to_str().unwrap()])
                                     .arg("-f")
                                     .args(if opts.quiet { Some("--quiet") } else { None })
                                     .arg("--git")

--- a/src/options.rs
+++ b/src/options.rs
@@ -111,7 +111,7 @@ impl Options {
 
         let all = matches.is_present("all");
         let update = !matches.is_present("list");
-        let cdir = cargo_dir();
+        let cdir = cargo_dir(matches.value_of("cargo-dir"));
         Options {
             to_update: match (all || !update, matches.values_of("PACKAGE")) {
                 (_, Some(pkgs)) => {
@@ -203,7 +203,7 @@ impl ConfigOptions {
             .get_matches();
         let matches = matches.subcommand_matches("install-update-config").unwrap();
 
-        let cdir = cargo_dir();
+        let cdir = cargo_dir(matches.value_of("cargo-dir"));
         ConfigOptions {
             crates_file: match matches.value_of("cargo-dir") {
                 Some(dir) => (format!("{}/.crates.toml", dir), fs::canonicalize(dir).unwrap().join(".crates.toml")),
@@ -256,26 +256,28 @@ impl ConfigOptions {
     }
 }
 
-fn cargo_dir() -> (String, PathBuf) {
-    match env::var("CARGO_HOME").map_err(|_| ()).and_then(|ch| fs::canonicalize(ch).map_err(|_| ())) {
-        Ok(ch) => ("$CARGO_HOME".to_string(), ch),
-        Err(()) =>
-                match home_dir().and_then(|hd| hd.canonicalize().ok()) {
-                    Some(mut hd) => {
-                        hd.push(".cargo");
+fn cargo_dir(opt_cargo_dir: Option<&str>) -> (String, PathBuf) {
+    if let Some(dir) = opt_cargo_dir {("cargo-dir".to_string(), PathBuf::from(dir))} else {
+        match env::var("CARGO_HOME").map_err(|_| ()).and_then(|ch| fs::canonicalize(ch).map_err(|_| ())) {
+            Ok(ch) => ("$CARGO_HOME".to_string(), ch),
+            Err(()) =>
+                    match home_dir().and_then(|hd| hd.canonicalize().ok()) {
+                        Some(mut hd) => {
+                            hd.push(".cargo");
 
-                        fs::create_dir_all(&hd).unwrap();
-                        ("$HOME/.cargo".to_string(), hd)
-                    }
-                    None => {
-                        clap::Error {
-                                message: "$CARGO_HOME and home directory invalid, please specify the cargo home directory with the -c option".to_string(),
-                                kind: clap::ErrorKind::MissingRequiredArgument,
-                                info: None,
-                            }
-                            .exit()
-                    }
-                },
+                            fs::create_dir_all(&hd).unwrap();
+                            ("$HOME/.cargo".to_string(), hd)
+                        }
+                        None => {
+                            clap::Error {
+                                    message: "$CARGO_HOME and home directory invalid, please specify the cargo home directory with the -c option".to_string(),
+                                    kind: clap::ErrorKind::MissingRequiredArgument,
+                                    info: None,
+                                }
+                                .exit()
+                        }
+                    },
+        }
     }
 }
 


### PR DESCRIPTION
The cargo root directory should be taken from the `--cargo-root` command line argument if it is given and should be passed to the `cargo install` command.

(Please note this is my first pull request for a project written in Rust so aplogies for any trivial mistakes)