### PR TITLE
Update regex to address CVE-2022-24713/RUSTSEC-2022-0013

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,8 +58,8 @@ libz-sys = "=1.1.6"
 # indirect via aho-corastick via regex
 # naming constants with `_` is unstable (see issue #54912)
 # non exhaustive is an experimental feature (see issue #44109)
-memchr = "=2.3.4"
-regex = "1.3"
+memchr = "2.4"
+regex = "1.6"
 serde = "1.0"
 # indirect via url
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/748120410#L254 vs https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/762755678#L262


### PR DESCRIPTION
See:
  * https://nvd.nist.gov/vuln/detail/cve-2022-24713
  * https://rustsec.org/advisories/RUSTSEC-2022-0013.html
  * https://github.com/rust-lang/regex/security/advisories/GHSA-m5pq-gvj9-9vr8

We also need to update memchr to meet the requirements of regex v1.6.0.