### PR TITLE
Ignore CVE-2022-24713/RUSTSEC-2022-0013 in cargo-audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,5 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2022-0013",        # We do not pass untrusted expressions to the
+                                # regex crate
+    ]

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *
 !.gitignore
 !.travis.yml
+!.cargo
+!.cargo/audit.toml
 !gh_rsa.enc
 !appveyor.yml
 !LICENSE


### PR DESCRIPTION
As described in https://github.com/nabijaczleweli/cargo-update/pull/193#issuecomment-1248184880, this project is unaffected by CVE-2022-24713/RUSTSEC-2022-0013 as it does not pass untrusted expressions to the regex crate.