### PR TITLE
Appveyor: Fix build by removing old workarounds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+- Visual Studio 2022
+
 version: 10.0.1-{build}
 
 skip_tags: false
@@ -9,20 +12,9 @@ clone_folder: C:\cargo-update
 
 install:
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%;C:\Users\appveyor\.cargo\bin
-  # https://www.msys2.org/news/#2020-05-17-32-bit-msys2-no-longer-actively-supported
-  - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-1~20201002-1-any.pkg.tar.xz -oC:\msys2-keyring.txz
-  - curl -SL http://repo.msys2.org/msys/x86_64/msys2-keyring-1~20220623-1-any.pkg.tar.zst -oC:\msys2-keyring.tzst
-  - curl -SL http://repo.msys2.org/msys/x86_64/zstd-1.4.7-1-x86_64.pkg.tar.xz -oC:\zstd.txz
-  - curl -SL http://repo.msys2.org/msys/x86_64/pacman-5.2.2-5-x86_64.pkg.tar.xz -oC:\pacman.txz
-  - pacman --noconfirm -U C:\msys2-keyring.txz
-  - pacman --noconfirm -U C:\zstd.txz
-  - pacman --noconfirm -U C:\pacman.txz
-  - pacman --noconfirm -U C:\msys2-keyring.tzst
-  - bash -lc "pacman --needed --noconfirm -Sy pacman-mirrors"
-  - bash -lc "pacman --noconfirm -Sy pacman"
-  - bash -lc "pacman --noconfirm -Sy"
-  - bash -lc "pacman --noconfirm -Su"
-  - bash -lc "pacman --noconfirm -Sy"
+  # https://www.msys2.org/docs/ci/#appveyor
+  - bash -lc "pacman --noconfirm -Syyu"
+  - bash -lc "pacman --noconfirm -Syyu"
   - bash -lc "pacman --noconfirm -S mingw-w64-x86_64-toolchain zip"
   -
   - mkdir target\release\deps


### PR DESCRIPTION
* Also explicitly spcecify VS2022 build image.
* Some commits were reverted especially these 3569e04b17c5f4cd15a6ea4006e1d1fd3f90c7f7 f95604fa3e15a0ff4604b343f2cfc64fe537edde