### PR TITLE
build: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,31 +50,27 @@ unicode-bidi = "=0.3.5"
 serde_derive = "1.0"
 lazy_static = "1.4"
 array_tool = "1.0"
-tabwriter = "1.1"
+tabwriter = "1.2"
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/773489449#L250
 bitflags = "=1.2.1"
 lazysort = "0.2"
 # error: unexpected token: `zng_prefix` &c. on bullseye cargo
 libz-sys = "=1.1.6"
-# indirect via aho-corastick via regex
-# naming constants with `_` is unstable (see issue #54912)
-# non exhaustive is an experimental feature (see issue #44109)
-memchr = "=2.3.4"
-regex = "1.3"
+regex = "1.6"
 serde = "1.0"
 # indirect via url
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/748120410#L254 vs https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/762755678#L262
 idna = "=0.2.0"
-git2 = "0.11"
-dirs = "2.0"
-json = "0.11"
+git2 = "0.15"
+dirs = "4.0"
+json = "0.12"
 toml = "0.5"
 # https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/748120410#L226 vs https://travis-ci.org/github/nabijaczleweli/cargo-update/jobs/762754635#L237
 hex = "=0.4.2"
-url = "2.1"
+url = "2.3"
 
 [dependencies.semver]
-version = "0.9"
+version = "1.0"
 features = ["serde"]
 
 [dependencies.clap]
@@ -86,7 +82,7 @@ features = ["wrap_help"]
 openssl-sys = "=0.9.70"
 
 [build-dependencies]
-embed-resource = "1.3"
+embed-resource = "1.7"
 
 [features]
 default = []

--- a/src/ops/config.rs
+++ b/src/ops/config.rs
@@ -9,7 +9,7 @@ use toml;
 
 
 /// A single operation to be executed upon configuration of a package.
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub enum ConfigOperation {
     /// Set the toolchain to use to compile the package.
     SetToolchain(String),
@@ -56,7 +56,7 @@ pub enum ConfigOperation {
 /// configuration.insert("cargo_update".to_string(), PackageConfig::from(&operations));
 /// PackageConfig::write(&configuration, &config_file).unwrap();
 /// ```
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PackageConfig {
     /// Toolchain to use to compile the package, or `None` for default.
     pub toolchain: Option<String>,


### PR DESCRIPTION
I used `cargo-edit` with `cargo upgrade --incompatible` to also update the major and minor numbers without touching at the pinned ones.

This notably updates the libgit2 dependency.

Fixes #203.