### PR TITLE
Expose option to vendor libgit2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ embed-resource = "1.7"
 [features]
 default = []
 vendored-openssl = ["git2/vendored-openssl"]
+vendored-libgit2 = ["git2/vendored-libgit2"]
 
 [[bin]]
 name = "cargo-install-update"


### PR DESCRIPTION
`git2-rs` already has an feature flag to enable vendoring of `libgit2`. This PR exposes the option for this crate so we can build and run on systems without the latest version of `libgit2`. This fixes #207.