### PR TITLE
Improve git error handling.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -372,7 +372,7 @@ fn actual_main() -> Result<(), i32> {
                          "{}\t{}\t{}\t{}",
                          package.name,
                          package.id,
-                         package.newest_id.clone().map(|x| x.to_string()).unwrap_or_else(|x| x),
+                         package.newest_id.clone().unwrap().map(|x| x.to_string()).unwrap_or_else(|x| x),
                          if package.needs_update() { "Yes" } else { "No" })
                     .unwrap();
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -372,7 +372,7 @@ fn actual_main() -> Result<(), i32> {
                          "{}\t{}\t{}\t{}",
                          package.name,
                          package.id,
-                         package.newest_id.as_ref().unwrap(),
+                         package.newest_id.clone().map(|x| x.to_string()).unwrap_or_else(|x| x),
                          if package.needs_update() { "Yes" } else { "No" })
                     .unwrap();
             }


### PR DESCRIPTION
This improves the behavior by not panicking on git errors, but showing the message. That way, the user knows which package the error comes from and additionally still gets a list of installed git packages.