### PR TITLE
Add progress output for git packages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -355,15 +355,25 @@ fn actual_main() -> Result<(), i32> {
             packages.retain(|p| opts.to_update.iter().any(|u| p.name == u.0));
         }
 
+        if !opts.quiet {
+            print!("    Pulling {} git packages", packages.len());
+            stdout().flush().unwrap();
+        }
+
         let git_db_dir = crates_file.with_file_name("git").join("db");
         for package in &mut packages {
             package.pull_version(&opts.temp_dir,
                                  &git_db_dir,
                                  http_proxy.as_ref().map(String::as_str),
                                  cargo_config.net_git_fetch_with_cli);
+            if !opts.quiet {
+                print!(".");
+                stdout().flush().unwrap();
+            }
         }
 
         if !opts.quiet {
+            println!("\n");
             let mut out = TabWriter::new(stdout());
             writeln!(out, "Package\tInstalled\tLatest\tNeeds update").unwrap();
             packages.sort_by(|lhs, rhs| (!lhs.needs_update(), &lhs.name).cmp(&(!rhs.needs_update(), &rhs.name)));


### PR DESCRIPTION
Small patch to add progress updates when pulling Git packages.

Example output:

```text
    Pulling 2 git packages..

Package   Installed                                 Latest                                    Needs update
cross     49338b18fdb82dedb2a813664e2e565ca73e2047  36c0d7810ddde073f603c82d896c2a6c886ff7a4  Yes
dota2cat  5ef445dd7448b3eac5e03e8602ccd8f6c81165c4  5ef445dd7448b3eac5e03e8602ccd8f6c81165c4  No
```

Similarly to the current progress output for polling the registry, it outputs a full stop/period for each Git repo as it's checked. This provides the user with a simple form of live status updates to let them know that `cargo-update` is working.

Pulling from multiple Git repos can take time, so it's useful to have status updates during this stage.
