### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
+
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ authors = ["наб <nabijaczleweli@nabijaczleweli.xyz>",
            "Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>"]
 exclude = ["*.enc"]
 edition = '2015'
-rust-version = "1.71.1"
+rust-version = "1.82"
 
 
 [dependencies]
@@ -55,8 +55,8 @@ tabwriter = "1.2"
 whoami = "1.5"
 serde = "1.0"
 git2 = "0.20"
-home = "=0.5.9"
-toml = "0.8"
+home = "0.5.11"
+toml = "0.9.1"
 hex = "0.4"
 url = "2.3"
 
@@ -73,7 +73,7 @@ version = "0.4"
 features = ["http2"]
 
 [build-dependencies]
-embed-resource = "2.4"
+embed-resource = "3"
 
 [features]
 default = []

--- a/build.rs
+++ b/build.rs
@@ -2,5 +2,5 @@ extern crate embed_resource;
 
 
 fn main() {
-    embed_resource::compile("cargo-install-update-manifest.rc", embed_resource::NONE);
+    embed_resource::compile("cargo-install-update-manifest.rc", embed_resource::NONE).manifest_required().unwrap();
 }

--- a/src/main-config.rs
+++ b/src/main-config.rs
@@ -16,7 +16,7 @@ fn actual_main() -> Result<(), i32> {
     let config_file = cargo_update::ops::crates_file_in(&opts.cargo_dir).with_file_name(".install_config.toml");
 
     let mut configuration = cargo_update::ops::PackageConfig::read(&config_file, &config_file.with_file_name(".crates2.json")).map_err(|(e, r)| {
-            eprintln!("Reading config: {}", e);
+            eprintln!("Reading config: {e}");
             r
         })?;
     if !opts.ops.is_empty() {
@@ -27,7 +27,7 @@ fn actual_main() -> Result<(), i32> {
         }
 
         cargo_update::ops::PackageConfig::write(&configuration, &config_file).map_err(|(e, r)| {
-                eprintln!("Writing config: {}", e);
+                eprintln!("Writing config: {e}");
                 r
             })?;
     }
@@ -35,28 +35,28 @@ fn actual_main() -> Result<(), i32> {
     if let Some(cfg) = configuration.get(&opts.package) {
         let mut out = TabWriter::new(stdout());
         if let Some(ref t) = cfg.toolchain {
-            writeln!(out, "Toolchain\t{}", t).unwrap();
+            writeln!(out, "Toolchain\t{t}").unwrap();
         }
         if let Some(p) = cfg.build_profile.as_deref().or_else(|| cfg.debug.and_then(|d| if d { Some("dev") } else { None })) {
-            writeln!(out, "Build profile\t{}", p).unwrap();
+            writeln!(out, "Build profile\t{p}").unwrap();
         }
         if let Some(ip) = cfg.install_prereleases {
-            writeln!(out, "Install prereleases\t{}", ip).unwrap();
+            writeln!(out, "Install prereleases\t{ip}").unwrap();
         }
         if let Some(el) = cfg.enforce_lock {
-            writeln!(out, "Enforce lock\t{}", el).unwrap();
+            writeln!(out, "Enforce lock\t{el}").unwrap();
         }
         if let Some(rb) = cfg.respect_binaries {
-            writeln!(out, "Respect binaries\t{}", rb).unwrap();
+            writeln!(out, "Respect binaries\t{rb}").unwrap();
         }
         if let Some(ref tv) = cfg.target_version {
-            writeln!(out, "Target version\t{}", tv).unwrap();
+            writeln!(out, "Target version\t{tv}").unwrap();
         }
         writeln!(out, "Default features\t{}", cfg.default_features).unwrap();
         if !cfg.features.is_empty() {
             write!(out, "Features").unwrap();
             for f in &cfg.features {
-                writeln!(out, "\t{}", f).unwrap();
+                writeln!(out, "\t{f}").unwrap();
             }
         }
         if let Some(env) = cfg.environment.as_ref() {
@@ -64,8 +64,8 @@ fn actual_main() -> Result<(), i32> {
                 write!(out, "Environment variables").unwrap();
                 for (var, val) in env {
                     match val {
-                        cargo_update::ops::EnvironmentOverride(Some(val)) => writeln!(out, "\t{}={}", var, val).unwrap(),
-                        cargo_update::ops::EnvironmentOverride(None) => writeln!(out, "\t{}\tcleared", var).unwrap(),
+                        cargo_update::ops::EnvironmentOverride(Some(val)) => writeln!(out, "\t{var}={val}").unwrap(),
+                        cargo_update::ops::EnvironmentOverride(None) => writeln!(out, "\t{var}\tcleared").unwrap(),
                     }
                 }
             }

--- a/src/options.rs
+++ b/src/options.rs
@@ -89,9 +89,9 @@ impl Options {
                 .args(&[Arg::from_usage("-c --cargo-dir=[CARGO_DIR] 'The cargo home directory. Default: $CARGO_HOME or $HOME/.cargo'")
                             .visible_alias("root")
                             .allow_invalid_utf8(true)
-                            .validator(|s| existing_dir_validator("Cargo", &s)),
+                            .validator(|s| existing_dir_validator("Cargo", s)),
                         Arg::from_usage("-t --temp-dir=[TEMP_DIR] 'The temporary directory. Default: $TEMP/cargo-update'")
-                            .validator(|s| existing_dir_validator("Temporary", &s)),
+                            .validator(|s| existing_dir_validator("Temporary", s)),
                         Arg::from_usage("-a --all 'Update all packages'"),
                         Arg::from_usage("-l --list 'Don't update packages, only list and check if they need an update (all packages by default)'"),
                         Arg::from_usage("-f --force 'Update all packages regardless if they need updating'"),
@@ -102,7 +102,7 @@ impl Options {
                         Arg::from_usage("--locked 'Enforce packages' embedded Cargo.lock'"),
                         Arg::from_usage("-s --filter=[PACKAGE_FILTER]... 'Specify a filter a package must match to be considered'")
                             .number_of_values(1)
-                            .validator(|s| PackageFilterElement::parse(&s).map(|_| ())),
+                            .validator(|s| PackageFilterElement::parse(s).map(|_| ())),
                         Arg::from_usage("-r --install-cargo=[EXECUTABLE] 'Specify an alternative cargo to run for installations'").allow_invalid_utf8(true),
                         Arg::from_usage("-j --jobs=[JOBS] 'Limit number of parallel jobs.'").allow_invalid_utf8(true),
                         Arg::with_name("cargo_install_opts")
@@ -131,15 +131,15 @@ impl Options {
                 (true, None) => vec![],
                 (false, None) => clerror(format_args!("Need at least one PACKAGE without --all")),
             },
-            all: all,
-            update: update,
+            all,
+            update,
             install: matches.is_present("allow-no-update"),
             force: matches.is_present("force"),
             downdate: matches.is_present("downdate"),
             update_git: matches.is_present("git"),
             quiet: matches.is_present("quiet"),
             locked: matches.is_present("locked"),
-            filter: matches.values_of("filter").map(|pfs| pfs.flat_map(PackageFilterElement::parse).collect()).unwrap_or_else(|| vec![]),
+            filter: matches.values_of("filter").map(|pfs| pfs.flat_map(PackageFilterElement::parse).collect()).unwrap_or_default(),
             cargo_dir: cargo_dir(matches.value_of_os("cargo-dir")),
             temp_dir: {
                 if let Some(tmpdir) = matches.value_of("temp-dir") {
@@ -168,12 +168,12 @@ impl ConfigOptions {
                 .author("https://github.com/nabijaczleweli/cargo-update")
                 .about("A cargo subcommand for checking and applying updates to installed executables -- configuration")
                 .args(&[Arg::from_usage("-c --cargo-dir=[CARGO_DIR] 'The cargo home directory. Default: $CARGO_HOME or $HOME/.cargo'")
-                            .validator(|s| existing_dir_validator("Cargo", &s)),
+                            .validator(|s| existing_dir_validator("Cargo", s)),
                         Arg::from_usage("-t --toolchain=[TOOLCHAIN] 'Toolchain to use or empty for default'"),
                         Arg::from_usage("-f --feature=[FEATURE]... 'Feature to enable'").number_of_values(1),
                         Arg::from_usage("-n --no-feature=[DISABLED_FEATURE]... 'Feature to disable'").number_of_values(1),
                         Arg::from_usage("-d --default-features=[DEFAULT_FEATURES] 'Whether to allow default features'")
-                            .possible_values(&["1", "yes", "true", "0", "no", "false"])
+                            .possible_values(["1", "yes", "true", "0", "no", "false"])
                             .hide_possible_values(true),
                         Arg::from_usage("--debug 'Compile the package in debug (\"dev\") mode'").conflicts_with("release").conflicts_with("build-profile"),
                         Arg::from_usage("--release 'Compile the package in release mode'").conflicts_with("debug").conflicts_with("build-profile"),
@@ -187,7 +187,7 @@ impl ConfigOptions {
                         Arg::from_usage("--respect-binaries 'Only install already installed binaries'").conflicts_with("no-respect-binaries"),
                         Arg::from_usage("--no-respect-binaries 'Install all binaries'").conflicts_with("respect-binaries"),
                         Arg::from_usage("-v --version=[VERSION_REQ] 'Require a cargo-compatible version range'")
-                            .validator(|s| SemverReq::from_str(&s).map(|_| ()).map_err(|e| e.to_string()))
+                            .validator(|s| SemverReq::from_str(s).map(|_| ()).map_err(|e| e.to_string()))
                             .conflicts_with("any-version"),
                         Arg::from_usage("-a --any-version 'Allow any version'").conflicts_with("version"),
                         Arg::from_usage("-e --environment=[VARIABLE=VALUE]... 'Environment variable to set'")
@@ -228,7 +228,7 @@ impl ConfigOptions {
                 .into_iter()
                 .chain(matches.values_of("feature").into_iter().flatten().map(str::to_string).map(ConfigOperation::AddFeature))
                 .chain(matches.values_of("no-feature").into_iter().flatten().map(str::to_string).map(ConfigOperation::RemoveFeature))
-                .chain(matches.value_of("default-features").map(|d| ["1", "yes", "true"].contains(&d)).map(ConfigOperation::DefaultFeatures).into_iter())
+                .chain(matches.value_of("default-features").map(|d| ["1", "yes", "true"].contains(&d)).map(ConfigOperation::DefaultFeatures))
                 .chain(match (matches.is_present("debug"), matches.is_present("release"), matches.value_of("build-profile")) {
                     (true, _, _) => Some(ConfigOperation::SetBuildProfile("dev".into())),
                     (_, true, _) => Some(ConfigOperation::SetBuildProfile("release".into())),
@@ -270,9 +270,9 @@ impl ConfigOptions {
 
 fn cargo_dir(opt_cargo_dir: Option<&OsStr>) -> (PathBuf, PathBuf) {
     if let Some(dir) = opt_cargo_dir {
-        match fs::canonicalize(&dir) {
+        match fs::canonicalize(dir) {
             Ok(cdir) => (dir.into(), cdir),
-            Err(_) => clerror(format_args!("--cargo-dir={:?} doesn't exist", dir)),
+            Err(_) => clerror(format_args!("--cargo-dir={dir:?} doesn't exist")),
         }
     } else {
         match env::var_os("CARGO_INSTALL_ROOT")
@@ -289,12 +289,12 @@ fn cargo_dir(opt_cargo_dir: Option<&OsStr>) -> (PathBuf, PathBuf) {
 }
 
 fn existing_dir_validator(label: &str, s: &str) -> Result<(), String> {
-    fs::canonicalize(s).map(|_| ()).map_err(|_| format!("{} directory \"{}\" not found", label, s))
+    fs::canonicalize(s).map(|_| ()).map_err(|_| format!("{label} directory \"{s}\" not found"))
 }
 
 fn package_parse(s: &str) -> Result<(String, Option<Semver>, String), String> {
     let mut registry_url = None;
-    let mut s = &s[..];
+    let mut s = s;
     if s.starts_with('(') {
         if let Some(idx) = s.find("):") {
             registry_url = Some(s[1..idx].to_string());
@@ -315,6 +315,6 @@ fn package_parse(s: &str) -> Result<(String, Option<Semver>, String), String> {
 
 
 fn clerror(f: Arguments) -> ! {
-    eprintln!("{}", f);
+    eprintln!("{f}");
     exit(1)
 }

--- a/tests/ops/assert_index_path.rs
+++ b/tests/ops/assert_index_path.rs
@@ -70,7 +70,7 @@ fn two() {
 }
 
 fn prep_indices(subname: &str) -> PathBuf {
-    let td = temp_dir().join("cargo_update-test").join(format!("assert_index_path-{}", subname));
+    let td = temp_dir().join("cargo_update-test").join(format!("assert_index_path-{subname}"));
     let _ = fs::create_dir_all(&td);
     td
 }
@@ -80,6 +80,6 @@ fn prepare_indices(index: &Path, shortnames: &[(&str, &str)]) {
     let _ = fs::create_dir_all(&index);
 
     for (name, hash) in shortnames {
-        let _ = fs::create_dir(index.join(format!("{}-{}", name, hash)));
+        let _ = fs::create_dir(index.join(format!("{name}-{hash}")));
     }
 }

--- a/tests/ops/get_index_url.rs
+++ b/tests/ops/get_index_url.rs
@@ -92,7 +92,7 @@ fn dead_end() {
 
 
 fn prep_config(subname: &str, suffix: &str) -> PathBuf {
-    let td = temp_dir().join("cargo_update-test").join(format!("get_index_url-{}-{}", subname, suffix));
+    let td = temp_dir().join("cargo_update-test").join(format!("get_index_url-{subname}-{suffix}"));
     let _ = fs::create_dir_all(&td);
 
     fs::write(td.join(suffix), TEST_DATA).unwrap();


### PR DESCRIPTION
### Updated
- Update dependencies
- Fix clippy warnings
- Bump MSRV to 1.82 (result of `cargo hack` and `cargo msrv`, has only been bumped in appveyor)
- Let dependabot update cargo and github-actions

### Not Updated
- `clap 4` 2022-09-28 ([breaking changes](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#400---2022-09-28))