### PR TITLE
Support listing non-crates.io packages

### DIFF
--- a/tests/ops/get_index_url.rs
+++ b/tests/ops/get_index_url.rs
@@ -90,6 +90,22 @@ fn dead_end() {
     }
 }
 
+#[test]
+fn ssh_registry_fails() {
+    for suffix in &["config", "config.toml"] {
+        let crates_file = prep_config("ssh_registry_fails", suffix);
+        fs::remove_file(crates_file.with_file_name(suffix)).unwrap();
+
+        assert!(get_index_url(&crates_file, "ssh://example.com/private-index", false).is_err());
+        
+        let error = get_index_url(&crates_file, "ssh://example.com/private-index", false).unwrap_err();
+        let error_msg = error.to_string();
+        assert!(error_msg.contains("Non-crates.io registry specified"));
+        assert!(error_msg.contains("no config file found"));
+        assert!(error_msg.contains("Due to a Cargo limitation"));
+    }
+}
+
 
 fn prep_config(subname: &str, suffix: &str) -> PathBuf {
     let td = temp_dir().join("cargo_update-test").join(format!("get_index_url-{}-{}", subname, suffix));

--- a/tests/ops/installed_registry_packages.rs
+++ b/tests/ops/installed_registry_packages.rs
@@ -53,3 +53,31 @@ fn non_existent() {
 
     assert_eq!(installed_registry_packages(&td.join(".crates.toml")), vec![]);
 }
+
+#[test]
+fn with_private_index_package() {
+    let mut td = temp_dir().join("cargo_update-test").join("installed_registry_packages-with-private-index");
+    let _ = fs::create_dir_all(&td);
+    td.push(".crates.toml");
+
+    let test_data = r#"[v1]
+"cargo-outdated 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = ["cargo-outdated.exe"]
+"treesize 0.2.1 (git+https://github.com/melak47/treesize-rs#742aebb3e66bd14421eb148e7f7981d50c6d1423)" = ["treesize.exe"]
+"problematic-package 1.0.0 (registry+ssh://example.com/private-index)" = ["problematic-package.exe"]
+"#;
+
+    File::create(&td).unwrap().write_all(test_data.as_bytes()).unwrap();
+
+    let packages = installed_registry_packages(&td);
+    
+    assert_eq!(packages.len(), 2);
+    
+    assert!(packages.iter().any(|p| p.name == "cargo-outdated"));
+    assert!(packages.iter().any(|p| p.name == "problematic-package"));
+    
+    assert!(!packages.iter().any(|p| p.name == "treesize"));
+    
+    let problematic = packages.iter().find(|p| p.name == "problematic-package").unwrap();
+    assert_eq!(problematic.registry, "ssh://example.com/private-index");
+}
+


### PR DESCRIPTION
This pull request introduces support for handling non-crates.io registry packages and adds corresponding tests. The changes ensure better error handling, filtering, and reporting for packages from private or unsupported registries.

### Problems I'd like to solve

This errors raises if the source is private installation with `cargo install xxx --index`
```
cargo install-update -l
Couldn't get registry for xcode-rust: Non-crates.io registry specified and ssh://xxxxx-index couldn't be found in the config file at /Users/xxx/.cargo/config.toml. Due to a Cargo limitation we will not be able to install from there until it's given a [source.NAME] in that file!.
```

### Screenshot

- `--list`
```
❯ ./target/debug/cargo-install-update install-update -l
Warning: Couldn't get registry for xcode-rust: Non-crates.io registry specified and ssh://xxx-index couldn't be found in the config file at /Users/xxx/.cargo/config.toml. Due to a Cargo limitation we will not be able to install from there until it's given a [source.NAME] in that file!.
    Updating registry 'https://code.byted.org/rust-lang/crates.byted.org-index'

    Polling registry 'https://rsproxy.cn/index/'...............................................

Package                   Installed  Latest                               Needs update
cargo-audit               v0.21.1    v0.21.2                              Yes
cargo-dylint              v2.6.1     v4.1.0                               Yes
cargo-expand              v1.0.106   v1.0.113                             Yes
...
tokei                     v12.1.2    v12.1.2 (v13.0.0-alpha.8 available)  No
trunk                     v0.21.14   v0.21.14                             No
wasm-tools                v1.235.0   v1.235.0                             No
zellij                    v0.42.2    v0.42.2                              No
xcode-rust                v0.1.7     N/A                                  N/A
```

- update
```
❯ ./target/debug/cargo-install-update install-update xcode-rust
Couldn't get registry for xcode-rust: Non-crates.io registry specified and ssh://xxx-index couldn't be found in the config file at /Users/xxx/.cargo/config.toml. Due to a Cargo limitation we will not be able to install from there until it's given a [source.NAME] in that file!.
```