### PR TITLE
fix: `mismatched_lifetime_syntaxes` compiler warnings

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1827,7 +1827,7 @@ pub enum RegistryTree<'a> {
 }
 
 /// Get `FETCH_HEAD` or `origin/HEAD`, then unwrap it to the tree it points to.
-pub fn parse_registry_head(registry_repo: &Registry) -> Result<RegistryTree, GitError> {
+pub fn parse_registry_head(registry_repo: &Registry) -> Result<RegistryTree<'_>, GitError> {
     match registry_repo {
         Registry::Git(registry_repo) => {
             registry_repo.revparse_single("FETCH_HEAD")
@@ -2084,7 +2084,7 @@ fn with_authentication<T, F>(url: &str, mut f: F) -> Result<T, GitError>
 
 
 /// Split and lower-case `cargo-update` into `[ca, rg, cargo-update]`, `jot` into `[3, j, jot]`, &c.
-pub fn split_package_path(cratename: &str) -> Vec<Cow<str>> {
+pub fn split_package_path(cratename: &str) -> Vec<Cow<'_, str>> {
     let mut elems = Vec::new();
     if cratename.is_empty() {
         panic!("0-length cratename");
@@ -2104,7 +2104,7 @@ pub fn split_package_path(cratename: &str) -> Vec<Cow<str>> {
     elems
 }
 
-fn lcase(s: &str) -> Cow<str> {
+fn lcase(s: &str) -> Cow<'_, str> {
     if s.bytes().any(|b| b.is_ascii_uppercase()) {
         s.to_ascii_lowercase().into()
     } else {


### PR DESCRIPTION
```
warning: unused `#[macro_use]` import
   --> src\lib.rs:389:1
    |
389 | #[macro_use]
    | ^^^^^^^^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src\ops\mod.rs:1830:43
     |
1830 | pub fn parse_registry_head(registry_repo: &Registry) -> Result<RegistryTree, GitError> {
     |                                           ^^^^^^^^^            ------------ the same lifetime is hidden here
     |                                           |
     |                                           the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
     = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
     |
1830 | pub fn parse_registry_head(registry_repo: &Registry) -> Result<RegistryTree<'_>, GitError> {
     |                                                                            ++++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src\ops\mod.rs:2087:38
     |
2087 | pub fn split_package_path(cratename: &str) -> Vec<Cow<str>> {
     |                                      ^^^^         -------- the same lifetime is hidden here
     |                                      |
     |                                      the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
2087 | pub fn split_package_path(cratename: &str) -> Vec<Cow<'_, str>> {
     |                                                       +++

warning: hiding a lifetime that's elided elsewhere is confusing
    --> src\ops\mod.rs:2107:13
     |
2107 | fn lcase(s: &str) -> Cow<str> {
     |             ^^^^     -------- the same lifetime is hidden here
     |             |
     |             the lifetime is elided here
     |
     = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
     |
2107 | fn lcase(s: &str) -> Cow<'_, str> {
     |                          +++

warning: `cargo-update` (lib) generated 4 warnings
```
```
❯ rustc -V
rustc 1.91.0-nightly (69b76df90 2025-08-23)
```