### PR TITLE
Implement --parallel-binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,8 @@ home = "=0.5.9"
 toml = "0.8"
 hex = "0.4"
 url = "2.3"
+jobserver = "0.1.34"
+std-semaphore = "0.1.0"
 
 [target.'cfg(target_vendor = "apple")'.dependencies.security-framework]
 version = "3.2"

--- a/src/options.rs
+++ b/src/options.rs
@@ -61,6 +61,8 @@ pub struct Options {
     pub install_cargo: Option<OsString>,
     /// Limit of concurrent jobs. Default: `None`
     pub jobs: Option<OsString>,
+    /// Limit of binaries compiled concurrently
+    pub parallel_binaries: u16,
 }
 
 /// Representation of the config application's all configurable values.
@@ -105,6 +107,7 @@ impl Options {
                             .validator(|s| PackageFilterElement::parse(&s).map(|_| ())),
                         Arg::from_usage("-r --install-cargo=[EXECUTABLE] 'Specify an alternative cargo to run for installations'").allow_invalid_utf8(true),
                         Arg::from_usage("-j --jobs=[JOBS] 'Limit number of parallel jobs.'").allow_invalid_utf8(true),
+                        Arg::from_usage("--parallel-binaries[NUMBER] 'Limit of binaries compiled concurrently.'"),
                         Arg::with_name("cargo_install_opts")
                             .long("__cargo_install_opts")
                             .env("CARGO_INSTALL_OPTS")
@@ -161,6 +164,7 @@ impl Options {
             cargo_install_args: matches.values_of_os("cargo_install_opts").into_iter().flat_map(|cio| cio.map(OsStr::to_os_string)).collect(),
             install_cargo: matches.value_of_os("install-cargo").map(OsStr::to_os_string),
             jobs: matches.value_of_os("jobs").map(OsStr::to_os_string),
+            parallel_binaries: matches.value_of("parallel-binaries").unwrap_or("0").parse().unwrap(),
         }
     }
 }


### PR DESCRIPTION
Closes: #57

To use, run `cargo install-update -af --parallel-binaries 4`. This might require 20 GB free RAM and 16 GB free `/tmp` disk space.

This only implements it for the most common usecase. The other usecases can be implemented later after someone performs cleanup. The progress bar isn't reimplemented here, as [Mach](https://firefox-source-docs.mozilla.org/mach/index.html) didn't either.

# Before

Most time was spent sequentially waiting on the linker (last) step for each binary. My 24 other CPU cores sat idle.

# After

With this feature enabled, each line has a bracketed prefix containing the package name as [requested](https://github.com/nabijaczleweli/cargo-update/issues/57#issuecomment-440457253). Build steps for different binaries can be seen interleaved. My CPU is kept busy basically throughout, except sometimes when there are 4 binaries linking.