### PR TITLE
Remove package.authors in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,42 +9,6 @@ license = "MIT"
 build = "build.rs"
 # Remember to also update in appveyor.yml
 version = "20.0.0"
-# Remember to also update in man/*.md
-authors = ["наб <nabijaczleweli@nabijaczleweli.xyz>",
-           "Yann Simon <yann.simon.fr@gmail.com>",
-           "ven <vendethiel@hotmail.fr>",
-           "Cat Plus Plus <piotrlegnica@piotrl.pl>",
-           "Liigo <liigo@qq.com>",
-           "azyobuzin <azyobuzin@users.sourceforge.jp>",
-           "Tatsuyuki Ishi <ishitatsuyuki@gmail.com>",
-           "Tom Prince <tom.prince@twistedmatrix.com>",
-           "Mateusz Mikuła <mati865@gmail.com>",
-           "sinkuu <sinkuupump@gmail.com>",
-           "Alex Burka <aburka@seas.upenn.edu>",
-           "Matthias Krüger <matthias.krueger@famsik.de>",
-           "Daniel Holbert <dholbert@cs.stanford.edu>",
-           "Jonas Bushart <jonas@bushart.org>",
-           "Harrison Metzger <harrisonmetz@gmail.com>",
-           "Benjamin Bannier <bbannier@gmail.com>",
-           "Dimitris Apostolou <dimitris.apostolou@icloud.com>",
-           "Corbin Uselton <corbinu@decimal.io>",
-           "QuarticCat <QuarticCat@protonmail.com>",
-           "Artur Sinila <freesoftware@logarithmus.dev>",
-           "qthree <qthree3@gmail.com>",
-           "tranzystorekk <tranzystorek.io@protonmail.com>",
-           "Paul Barker <paul@pbarker.dev>",
-           "Benoît Cortier",
-           "Biswapriyo Nath <nathbappai@gmail.com>",
-           "Shiraz <smcclennon@protonmail.com>",
-           "Victor Song <vms2@rice.edu>",
-           "chrisalcantara <chris@chrisalcantara.com>",
-           "Utkarsh Gupta <utkarshgupta137@gmail.com>",
-           "nevsal",
-           "Rui Chen <https://chenrui.dev>",
-           "Lynnesbian <https://fedi.lynnesbian.space/@lynnesbian>",
-           "Rene Leonhardt",
-           "Maxime Guerreiro <maxime@cloudflare.com>",
-           "Brian"]
 exclude = ["*.enc"]
 edition = '2015'
 rust-version = "1.71.1"


### PR DESCRIPTION
`package.authors` is deprecated: rust-lang/cargo#15068