### PR TITLE
Fix panic when setting cargo-dir

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -277,7 +277,7 @@ impl ConfigOptions {
         let (_, mut matches) = matches.remove_subcommand().unwrap();
 
         ConfigOptions {
-            cargo_dir: cargo_dir(matches.get_one("cargo-dir")).1,
+            cargo_dir: cargo_dir(matches.get_one("cargo-dir").cloned()).1,
             package: matches.remove_one("PACKAGE").unwrap(),
             ops: matches.remove_one("toolchain")
                 .map(|t: String| if t.is_empty() {
@@ -333,7 +333,7 @@ impl ConfigOptions {
     }
 }
 
-fn cargo_dir(opt_cargo_dir: Option<&PathBuf>) -> (PathBuf, PathBuf) {
+fn cargo_dir(opt_cargo_dir: Option<PathBuf>) -> (PathBuf, PathBuf) {
     if let Some(dir) = opt_cargo_dir {
         match fs::canonicalize(&dir) {
             Ok(cdir) => (dir.into(), cdir),


### PR DESCRIPTION
cargo-update 20.0.2 would crash when cargo-dir was set with the following

```
thread 'main' (735889) panicked at src/options.rs:194:42:
Mismatch between definition and access of `cargo-dir`. Could not downcast to &std::path::PathBuf, need to downcast to std::path::PathBuf
```

This changes the sig of `cargo_dir` to take a `PathBuf` instead of a ref to a `PathBuf`.