### PR TITLE
Don't hang when a package has been deleted from the registry

### DIFF
--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -1920,12 +1920,10 @@ struct SparseHandler<'m, 'w: 'm, W: Write>(String,
 
 impl<'m, 'w: 'm, W: Write> CurlHandler for SparseHandler<'m, 'w, W> {
     fn write(&mut self, data: &[u8]) -> Result<usize, CurlWriteError> {
-        let mut consumed = 0;
         self.1 = mem::replace(&mut self.1, Err("write".into())).and_then(|(mut vers, mut buf)| {
             for l in data.split_inclusive(|&b| b == b'\n') {
                 if !l.ends_with(b"\n") {
                     buf.extend(l);
-                    consumed += l.len();
                     continue;
                 }
 
@@ -1937,11 +1935,15 @@ impl<'m, 'w: 'm, W: Write> CurlHandler for SparseHandler<'m, 'w, W> {
                 };
                 vers.extend(crate_version_line(line)?);
                 buf.clear();
-                consumed += l.len();
             }
             Ok((vers, buf))
         });
-        Ok(consumed)
+        // Always claim the whole buffer, even if parsing failed: a short write is fatal to curl, and it tears down the shared HTTP/2
+        // session along with all the other transfers multiplexed onto it, which then never complete, so `curl_multi_perform()`
+        // keeps reporting them as running forever. This is easy to hit, since error pages (404 &c.) are fed here too, and never
+        // parse. The parse error is remembered in `self.1` and surfaced once the transfer is done, by which point we know the
+        // response code.
+        Ok(data.len())
     }
 
     fn progress(&mut self, dltotal: f64, dlnow: f64, _: f64, _: f64) -> bool {

--- a/tests/ops/registry_package/mod.rs
+++ b/tests/ops/registry_package/mod.rs
@@ -1,1 +1,2 @@
+mod pull_version;
 mod parse;

--- a/tests/ops/registry_package/pull_version.rs
+++ b/tests/ops/registry_package/pull_version.rs
@@ -1,0 +1,28 @@
+use cargo_update::ops::{RegistryPackage, RegistryTree, Registry};
+
+
+/// A package deleted from the registry has nothing to update to, but mustn't blow up.
+///
+/// As left by `update_index()`: polled, HTTP 404, no entry at all.
+#[test]
+fn deleted_from_registry() {
+    assert!(!check(&Registry::Sparse(Default::default())));
+}
+
+/// A package whose entry exists but lists no versions is still in the registry, just not updatable.
+#[test]
+fn no_versions() {
+    assert!(check(&Registry::Sparse([("gone".to_string(), vec![])].into())));
+}
+
+fn check(registry: &Registry) -> bool {
+    let mut package = RegistryPackage::parse("gone 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)", vec!["gone".to_string()]).unwrap();
+
+    let in_registry = package.pull_version(&RegistryTree::Sparse, registry, None, None);
+
+    assert_eq!(package.newest_version, None);
+    assert_eq!(package.update_to_version(), None);
+    assert!(!package.needs_update(None, None, false));
+    assert!(!package.needs_update(None, None, true));
+    in_registry
+}


### PR DESCRIPTION
When a sparse registry response didn't parse, the write callback returned only the number of bytes it had consumed. curl treats a short write as fatal and drops the HTTP/2 connection, taking every other transfer sharing it down too. Those never finish, so `curl_multi_perform()` keeps reporting them as running and the run hangs. Return the full length instead; the parse error is still saved and reported once the transfer is done.

Error pages don't parse, so one deleted package was enough to hang -a.

`pull_version()` also panicked when a package wasn't in the index, so make it return no versions instead.

Closes #342.